### PR TITLE
feat: increase max values for lf tags

### DIFF
--- a/internal/service/lakeformation/lakeformation_test.go
+++ b/internal/service/lakeformation/lakeformation_test.go
@@ -50,9 +50,10 @@ func TestAccLakeFormation_serial(t *testing.T) {
 			"wildcardSelectPlus":      testAccPermissions_twcWildcardSelectPlus,
 		},
 		"LFTags": {
-			"basic":      testAccLFTag_basic,
-			"disappears": testAccLFTag_disappears,
-			"values":     testAccLFTag_values,
+			"basic":       testAccLFTag_basic,
+			"many_values": testAccLFTag_many_values,
+			"disappears":  testAccLFTag_disappears,
+			"values":      testAccLFTag_values,
 		},
 		"ResourceLFTags": {
 			"basic":            testAccResourceLFTags_basic,

--- a/internal/service/lakeformation/lf_tag.go
+++ b/internal/service/lakeformation/lf_tag.go
@@ -15,6 +15,9 @@ import (
 	"github.com/hashicorp/terraform-provider-aws/internal/flex"
 )
 
+// This value is defined by AWS API
+const lfTagsValuesMaxBatchSize = 50
+
 func ResourceLFTag() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceLFTagCreate,
@@ -42,7 +45,7 @@ func ResourceLFTag() *schema.Resource {
 				Type:     schema.TypeSet,
 				Required: true,
 				MinItems: 1,
-				MaxItems: 15,
+				MaxItems: 500,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: validateLFTagValues(),
@@ -58,6 +61,7 @@ func resourceLFTagCreate(d *schema.ResourceData, meta interface{}) error {
 
 	tagKey := d.Get("key").(string)
 	tagValues := d.Get("values").(*schema.Set)
+	tagValuesLen := tagValues.Len()
 
 	var catalogID string
 	if v, ok := d.GetOk("catalog_id"); ok {
@@ -66,15 +70,43 @@ func resourceLFTagCreate(d *schema.ResourceData, meta interface{}) error {
 		catalogID = meta.(*conns.AWSClient).AccountID
 	}
 
+	end := lfTagsValuesMaxBatchSize
+	if end > tagValuesLen {
+		end = tagValuesLen
+	}
+
+	valuesSubset := schema.NewSet(tagValues.F, tagValues.List()[0:end])
 	input := &lakeformation.CreateLFTagInput{
 		CatalogId: aws.String(catalogID),
 		TagKey:    aws.String(tagKey),
-		TagValues: flex.ExpandStringSet(tagValues),
+		TagValues: flex.ExpandStringSet(valuesSubset),
 	}
 
 	_, err := conn.CreateLFTag(input)
 	if err != nil {
 		return fmt.Errorf("error creating Lake Formation LF-Tag: %w", err)
+	}
+
+	// If there are more than 50 values, create them in batches of 50 using UpdateLFTag API
+	for i := 50; i < tagValuesLen; i += lfTagsValuesMaxBatchSize {
+		end := i + lfTagsValuesMaxBatchSize
+
+		if end > tagValuesLen {
+			end = tagValuesLen
+		}
+
+		subset := schema.NewSet(tagValues.F, tagValues.List()[i:end])
+
+		input := &lakeformation.UpdateLFTagInput{
+			CatalogId:      aws.String(catalogID),
+			TagKey:         aws.String(tagKey),
+			TagValuesToAdd: flex.ExpandStringSet(subset),
+		}
+
+		_, err := conn.UpdateLFTag(input)
+		if err != nil {
+			return fmt.Errorf("error creating Lake Formation LF-Tag (batch: %d to %d): %w", i, end, err)
+		}
 	}
 
 	d.SetId(fmt.Sprintf("%s:%s", catalogID, tagKey))
@@ -126,25 +158,41 @@ func resourceLFTagUpdate(d *schema.ResourceData, meta interface{}) error {
 	o, n := d.GetChange("values")
 	os := o.(*schema.Set)
 	ns := n.(*schema.Set)
-	toAdd := flex.ExpandStringSet(ns.Difference(os))
-	toDelete := flex.ExpandStringSet(os.Difference(ns))
+	toAdd := ns.Difference(os)
+	toDelete := os.Difference(ns)
+	toAddLen := toAdd.Len()
+	toDeleteLen := toDelete.Len()
 
-	input := &lakeformation.UpdateLFTagInput{
-		CatalogId: aws.String(catalogID),
-		TagKey:    aws.String(tagKey),
-	}
+	for i := 0; i < Max(toAddLen, toDeleteLen); i += lfTagsValuesMaxBatchSize {
+		input := &lakeformation.UpdateLFTagInput{
+			CatalogId: aws.String(catalogID),
+			TagKey:    aws.String(tagKey),
+		}
 
-	if len(toAdd) > 0 {
-		input.TagValuesToAdd = toAdd
-	}
+		if i < toAddLen {
+			end := i + lfTagsValuesMaxBatchSize
+			if end > toAddLen {
+				end = toAddLen
+			}
 
-	if len(toDelete) > 0 {
-		input.TagValuesToDelete = toDelete
-	}
+			toAddSubset := schema.NewSet(toAdd.F, toAdd.List()[i:end])
+			input.TagValuesToAdd = flex.ExpandStringSet(toAddSubset)
+		}
 
-	_, err = conn.UpdateLFTag(input)
-	if err != nil {
-		return fmt.Errorf("error updating Lake Formation LF-Tag (%s): %w", d.Id(), err)
+		if i < toDeleteLen {
+			end := i + lfTagsValuesMaxBatchSize
+			if end > toDeleteLen {
+				end = toDeleteLen
+			}
+
+			toDeleteSubset := schema.NewSet(toAdd.F, toDelete.List()[i:end])
+			input.TagValuesToDelete = flex.ExpandStringSet(toDeleteSubset)
+		}
+
+		_, err := conn.UpdateLFTag(input)
+		if err != nil {
+			return fmt.Errorf("error updating Lake Formation LF-Tag (%s) (batch %d): %w", d.Id(), i, err)
+		}
 	}
 
 	return resourceLFTagRead(d, meta)
@@ -184,4 +232,11 @@ func validateLFTagValues() schema.SchemaValidateFunc {
 		validation.StringLenBetween(1, 255),
 		validation.StringMatch(regexp.MustCompile(`^([\p{L}\p{Z}\p{N}_.:\*\/=+\-@%]*)$`), ""),
 	)
+}
+
+func Max(x, y int) int {
+	if x > y {
+		return x
+	}
+	return y
 }

--- a/internal/service/lakeformation/lf_tag_test.go
+++ b/internal/service/lakeformation/lf_tag_test.go
@@ -45,6 +45,35 @@ func testAccLFTag_basic(t *testing.T) {
 	})
 }
 
+func testAccLFTag_many_values(t *testing.T) {
+	resourceName := "aws_lakeformation_lf_tag.test"
+	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t); acctest.PreCheckPartitionHasService(lakeformation.EndpointsID, t) },
+		ErrorCheck:               acctest.ErrorCheck(t, lakeformation.EndpointsID),
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories,
+		CheckDestroy:             testAccCheckLFTagsDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLFTagConfig_manyvalues(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLFTagExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "key", rName),
+					resource.TestCheckResourceAttr(resourceName, "values.0", "value1"),
+					testAccCheckLFTagValuesLen(resourceName, 52),
+					acctest.CheckResourceAttrAccountID(resourceName, "catalog_id"),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccLFTag_disappears(t *testing.T) {
 	resourceName := "aws_lakeformation_lf_tag.test"
 	rName := sdkacctest.RandomWithPrefix(acctest.ResourcePrefix)
@@ -94,12 +123,23 @@ func testAccLFTag_values(t *testing.T) {
 			},
 			{
 				// Test an update that adds, removes and retains a tag value
-				Config: testAccLFTagConfig_values(rName, []string{"value1", "value3"}),
+				Config: testAccLFTagConfig_values(rName, []string{"value1", "value3", "value4", "value5", "value6", "value7", "value8", "value9", "value10", "value11", "value12", "value13", "value14", "value15", "value16", "value17", "value18", "value19", "value20", "value21", "value22", "value23", "value24", "value25", "value26", "value27", "value28", "value29", "value30", "value31", "value32", "value33", "value34", "value35", "value36", "value37", "value38", "value39", "value40", "value41", "value42", "value43", "value44", "value45", "value46", "value47", "value48", "value49", "value50", "value51", "value52", "value53", "value54", "value55", "value56", "value57", "value58", "value59", "value60", "value61", "value62", "value63", "value64", "value65", "value66", "value67", "value68", "value69", "value70", "value71", "value72", "value73", "value74", "value75", "value76", "value77", "value78", "value79", "value80", "value81", "value82", "value83", "value84", "value85", "value86", "value87", "value88", "value89", "value90", "value91", "value92", "value93", "value94", "value95", "value96", "value97", "value98", "value99", "value100", "value101", "value102", "value103", "value104", "value105", "value106", "value107", "value108", "value109", "value110", "value111", "value112", "value113", "value114", "value115", "value116", "value117", "value118", "value119", "value120", "value121", "value122", "value123", "value124", "value125", "value126", "value127", "value128", "value129", "value130", "value131", "value132", "value133", "value134", "value135", "value136", "value137", "value138", "value139", "value140", "value141"}),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLFTagExists(resourceName),
 					resource.TestCheckResourceAttr(resourceName, "key", rName),
 					resource.TestCheckResourceAttr(resourceName, "values.0", "value1"),
-					resource.TestCheckResourceAttr(resourceName, "values.1", "value3"),
+					testAccCheckLFTagValuesLen(resourceName, 140),
+					acctest.CheckResourceAttrAccountID(resourceName, "catalog_id"),
+				),
+			},
+			{
+				// Test an update that adds, removes and retains many values
+				Config: testAccLFTagConfig_values(rName, []string{"value1", "value3", "value4", "value5", "value6", "value7", "value8", "value9", "value10", "value160", "value161", "value162", "value163", "value164", "value165", "value166", "value167", "value168", "value169", "value170", "value171", "value172", "value173", "value174", "value175", "value176", "value177", "value178", "value179", "value180", "value181", "value182", "value183", "value184", "value185", "value186", "value187", "value188", "value189", "value190", "value191", "value192", "value193", "value194", "value195", "value196", "value197", "value198", "value199", "value200", "value201", "value202", "value203", "value204", "value205", "value206", "value207", "value208", "value209", "value210", "value211", "value212", "value213", "value214", "value215", "value216", "value217", "value218", "value219", "value220"}),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLFTagExists(resourceName),
+					resource.TestCheckResourceAttr(resourceName, "key", rName),
+					resource.TestCheckResourceAttr(resourceName, "values.0", "value1"),
+					testAccCheckLFTagValuesLen(resourceName, 70),
 					acctest.CheckResourceAttrAccountID(resourceName, "catalog_id"),
 				),
 			},
@@ -169,6 +209,42 @@ func testAccCheckLFTagExists(name string) resource.TestCheckFunc {
 	}
 }
 
+func testAccCheckLFTagValuesLen(name string, expected_len int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("not found: %s", name)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("no ID is set")
+		}
+
+		catalogID, tagKey, err := tflakeformation.ReadLFTagID(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		input := &lakeformation.GetLFTagInput{
+			CatalogId: aws.String(catalogID),
+			TagKey:    aws.String(tagKey),
+		}
+
+		conn := acctest.Provider.Meta().(*conns.AWSClient).LakeFormationConn
+		output, err := conn.GetLFTag(input)
+
+		if len(output.TagValues) != expected_len {
+			return fmt.Errorf("expected %d values, got %d", expected_len, len(output.TagValues))
+		}
+
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
 func testAccLFTagConfig_basic(rName string) string {
 	return fmt.Sprintf(`
 data "aws_caller_identity" "current" {}
@@ -184,6 +260,27 @@ resource "aws_lakeformation_data_lake_settings" "test" {
 resource "aws_lakeformation_lf_tag" "test" {
   key    = %[1]q
   values = ["value"]
+  # for consistency, ensure that admins are setup before testing
+  depends_on = [aws_lakeformation_data_lake_settings.test]
+}
+`, rName)
+}
+
+func testAccLFTagConfig_manyvalues(rName string) string {
+	return fmt.Sprintf(`
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_session_context" "current" {
+  arn = data.aws_caller_identity.current.arn
+}
+
+resource "aws_lakeformation_data_lake_settings" "test" {
+  admins = [data.aws_iam_session_context.current.issuer_arn]
+}
+
+resource "aws_lakeformation_lf_tag" "test" {
+  key    = %[1]q
+  values = ["value1", "value2", "value3", "value4", "value5", "value6", "value7", "value8", "value9", "value10", "value11", "value12", "value13", "value14", "value15", "value16", "value17", "value18", "value19", "value20", "value21", "value22", "value23", "value24", "value25", "value26", "value27", "value28", "value29", "value30", "value31", "value32", "value33", "value34", "value35", "value36", "value37", "value38", "value39", "value40", "value41", "value42", "value43", "value44", "value45", "value46", "value47", "value48", "value49", "value50", "value51", "value52"]
   # for consistency, ensure that admins are setup before testing
   depends_on = [aws_lakeformation_data_lake_settings.test]
 }


### PR DESCRIPTION
<!--- See what makes a good Pull Request at : https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/contributing --->

<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" or other comments that do not add relevant new information or questions, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

<!--- If your PR fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates --->
### Feature details
When using the AWS console to create a LF Tag and its values, we can only define 15 values. However when using the `aws cli` and the API, the maximum values allowed per call is 50. Furthermore, it's indicated in this [documentation](https://docs.aws.amazon.com/lake-formation/latest/dg/TBAC-notes.html) that the soft-limit for values per tag is 1000.

This PR allows user to create tag values up to this limit.

<ins>Output from acceptance testing:</ins>

<!--
Replace TestAccXXX with a pattern that matches the tests affected by this PR.

Replace ec2 with the service package corresponding to your tests.

For more information on the `-run` flag, see the `go test` documentation at https://tip.golang.org/cmd/go/#hdr-Testing_flags.
-->
```
$ make testacc TESTS=TestAccLakeFormation_serial/LFTags PKG=lakeformation

TF_ACC=1 go test ./internal/service/lakeformation/... -v -count 1 -parallel 20 -run='TestAccLakeFormation_serial/LFTags'  -timeout 180m
=== RUN   TestAccLakeFormation_serial
=== RUN   TestAccLakeFormation_serial/LFTags
=== RUN   TestAccLakeFormation_serial/LFTags/basic
=== RUN   TestAccLakeFormation_serial/LFTags/many_values
=== RUN   TestAccLakeFormation_serial/LFTags/disappears
=== RUN   TestAccLakeFormation_serial/LFTags/values
=== RUN   TestAccLakeFormation_serial/ResourceLFTags
=== RUN   TestAccLakeFormation_serial/ResourceLFTags/tableWithColumns
=== RUN   TestAccLakeFormation_serial/ResourceLFTags/basic
=== RUN   TestAccLakeFormation_serial/ResourceLFTags/database
=== RUN   TestAccLakeFormation_serial/ResourceLFTags/databaseMultiple
=== RUN   TestAccLakeFormation_serial/ResourceLFTags/table
--- PASS: TestAccLakeFormation_serial (134.03s)
    --- PASS: TestAccLakeFormation_serial/LFTags (51.81s)
        --- PASS: TestAccLakeFormation_serial/LFTags/basic (9.82s)
        --- PASS: TestAccLakeFormation_serial/LFTags/many_values (9.46s)
        --- PASS: TestAccLakeFormation_serial/LFTags/disappears (8.06s)
        --- PASS: TestAccLakeFormation_serial/LFTags/values (24.46s)
    --- PASS: TestAccLakeFormation_serial/ResourceLFTags (82.22s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/tableWithColumns (19.14s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/basic (8.98s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/database (17.03s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/databaseMultiple (18.12s)
        --- PASS: TestAccLakeFormation_serial/ResourceLFTags/table (18.95s)
PASS
ok  	github.com/hashicorp/terraform-provider-aws/internal/service/lakeformation	135.724s
```
